### PR TITLE
Exported IsAuthorized.

### DIFF
--- a/hookshot.go
+++ b/hookshot.go
@@ -83,7 +83,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	sig, ok := authorized(req, route.Secret)
+	sig, ok := IsAuthorized(req, route.Secret)
 
 	if r.SetHeader {
 		w.Header().Set("X-Calculated-Signature", sig)
@@ -140,9 +140,11 @@ func Signature(body []byte, secret string) string {
 	return fmt.Sprintf("%x", mac.Sum(nil))
 }
 
-// authorized checks that the calculated signature for the request matches the provided signature in
-// the request headers.
-func authorized(r *http.Request, secret string) (string, bool) {
+// IsAuthorized checks that the calculated signature for the request matches the provided signature in
+// the request headers. Returns the calculated signature, and a boolean value
+// indicating whether or not the calculated signature matches the
+// X-Hub-Signature value.
+func IsAuthorized(r *http.Request, secret string) (string, bool) {
 	raw, er := ioutil.ReadAll(r.Body)
 	if er != nil {
 		return "", false

--- a/hookshot_test.go
+++ b/hookshot_test.go
@@ -143,7 +143,7 @@ func TestSignature(t *testing.T) {
 	}
 }
 
-func ExampleRouter_HandleFunc() {
+func ExampleRouterHandleFunc() {
 	r := NewRouter("secret")
 	r.HandleFunc("ping", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`pong`))
@@ -158,4 +158,24 @@ func ExampleRouter_HandleFunc() {
 
 	fmt.Print(res.Body)
 	// Output: pong
+}
+
+func ExampleIsAuthorized() {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, ok := IsAuthorized(r, "secret"); !ok {
+			http.Error(w, "The provided signature in the "+HeaderSignature+" header does not match.", 403)
+			return
+		}
+
+		w.Write([]byte(`Ok`))
+	})
+
+	res := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "", bytes.NewBufferString(`{"data":"foo"}`))
+	req.Header.Set("X-Hub-Signature", "sha1=b3dc4e9a2d727ee1e60bb6828c2dcef88b5ec970")
+
+	h.ServeHTTP(res, req)
+
+	fmt.Print(res.Body)
+	// Output: Ok
 }


### PR DESCRIPTION
This exports the `authorized` func as `IsAuthorized`, which can be useful for applications that want to verify the authenticity of a request, without using the Router.