### PR TITLE
Don't enforce global signature checking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,12 @@ Hookshot is a Go http router that de-multiplexes and authorizes GitHub Webhooks.
 r := hookshot.NewRouter()
 
 r.Handle("deployment_status", DeploymentStatusHandler)
-r.HandleSecret("deployment", "secret", DeploymentHandler)
+r.Handle("deployment", DeploymentHandler)
+```
+
+To automatically verify the `X-Hub-Signature`:
+
+
+```go
+r.Handle("deployment", hookshot.Authorize(DeploymentHandler, "secret"))
 ```

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ Hookshot is a Go http router that de-multiplexes and authorizes GitHub Webhooks.
 ```go
 r := hookshot.NewRouter()
 
-r.Handle("deployment", DeploymentHandler)
 r.Handle("deployment_status", DeploymentStatusHandler)
-```
-
-To automatically verify that the request came from GitHub using a secret:
-
-```go
-r := hookshot.NewRouterWithSecret("secret")
+r.HandleSecret("deployment", "secret", DeploymentHandler)
 ```

--- a/README.md
+++ b/README.md
@@ -8,8 +8,14 @@ Hookshot is a Go http router that de-multiplexes and authorizes GitHub Webhooks.
 ## Usage
 
 ```go
-r := hookshot.NewRouter("secret")
+r := hookshot.NewRouter()
 
 r.Handle("deployment", DeploymentHandler)
 r.Handle("deployment_status", DeploymentStatusHandler)
+```
+
+To automatically verify that the request came from GitHub using a secret:
+
+```go
+r := hookshot.NewRouterWithSecret("secret")
 ```

--- a/example_test.go
+++ b/example_test.go
@@ -16,7 +16,7 @@ func HandlePing(w http.ResponseWriter, r *http.Request) {
 }
 
 func Example() {
-	r := hookshot.NewRouterWithSecret("secret")
+	r := hookshot.NewRouter()
 	r.HandleFunc("ping", HandlePing)
 
 	http.ListenAndServe(":8080", r)

--- a/example_test.go
+++ b/example_test.go
@@ -16,7 +16,7 @@ func HandlePing(w http.ResponseWriter, r *http.Request) {
 }
 
 func Example() {
-	r := hookshot.NewRouter("secret")
+	r := hookshot.NewRouterWithSecret("secret")
 	r.HandleFunc("ping", HandlePing)
 
 	http.ListenAndServe(":8080", r)

--- a/hookshot.go
+++ b/hookshot.go
@@ -38,10 +38,6 @@ type Router struct {
 	// The nil value for NotFoundHandler
 	NotFoundHandler http.Handler
 
-	// UnauthorizedHandler is called when the calculated signature does not match the
-	// provided signature in the X-Hub-Signature header.
-	UnauthorizedHandler http.Handler
-
 	routes routes
 }
 

--- a/hookshot_test.go
+++ b/hookshot_test.go
@@ -17,7 +17,7 @@ type payload struct {
 	event string `json:"event"`
 }
 
-func TestRouter(t *testing.T) {
+func TestRouterAuthorized(t *testing.T) {
 	tests := []struct {
 		secret    string
 		event     string
@@ -69,7 +69,7 @@ func TestRouter(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		router := NewRouter(tt.secret)
+		router := NewRouterWithSecret(tt.secret)
 
 		router.HandleFunc("deployment", func(w http.ResponseWriter, r *http.Request) {
 			var p payload
@@ -144,7 +144,7 @@ func TestSignature(t *testing.T) {
 }
 
 func ExampleRouterHandleFunc() {
-	r := NewRouter("secret")
+	r := NewRouterWithSecret("secret")
 	r.HandleFunc("ping", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`pong`))
 	})

--- a/hookshot_test.go
+++ b/hookshot_test.go
@@ -71,7 +71,7 @@ func TestRouterAuthorized(t *testing.T) {
 	for _, tt := range tests {
 		router := NewRouter()
 
-		router.HandleSecret("deployment", tt.secret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		router.Handle("deployment", Authorize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var p payload
 			err := json.NewDecoder(r.Body).Decode(&p)
 
@@ -81,7 +81,7 @@ func TestRouterAuthorized(t *testing.T) {
 
 			w.WriteHeader(200)
 			w.Write([]byte("ok\n"))
-		}))
+		}), tt.secret))
 
 		resp := httptest.NewRecorder()
 		req, _ := http.NewRequest("POST", "/", bytes.NewReader([]byte(tt.body)))
@@ -145,9 +145,9 @@ func TestSignature(t *testing.T) {
 
 func ExampleRouterHandleFunc() {
 	r := NewRouter()
-	r.HandleSecret("ping", "secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	r.Handle("ping", Authorize(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`pong`))
-	}))
+	}), "secret"))
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "", bytes.NewBufferString(`{"data":"foo"}`))

--- a/hookshot_test.go
+++ b/hookshot_test.go
@@ -69,9 +69,9 @@ func TestRouterAuthorized(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		router := NewRouterWithSecret(tt.secret)
+		router := NewRouter()
 
-		router.HandleFunc("deployment", func(w http.ResponseWriter, r *http.Request) {
+		router.HandleSecret("deployment", tt.secret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var p payload
 			err := json.NewDecoder(r.Body).Decode(&p)
 
@@ -81,7 +81,7 @@ func TestRouterAuthorized(t *testing.T) {
 
 			w.WriteHeader(200)
 			w.Write([]byte("ok\n"))
-		})
+		}))
 
 		resp := httptest.NewRecorder()
 		req, _ := http.NewRequest("POST", "/", bytes.NewReader([]byte(tt.body)))
@@ -144,10 +144,10 @@ func TestSignature(t *testing.T) {
 }
 
 func ExampleRouterHandleFunc() {
-	r := NewRouterWithSecret("secret")
-	r.HandleFunc("ping", func(w http.ResponseWriter, r *http.Request) {
+	r := NewRouter()
+	r.HandleSecret("ping", "secret", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(`pong`))
-	})
+	}))
 
 	res := httptest.NewRecorder()
 	req, _ := http.NewRequest("POST", "", bytes.NewBufferString(`{"data":"foo"}`))


### PR DESCRIPTION
`NewRouter` now returns a router that will not perform any verification of the signature. It's responsibility is to only route based on the `X-GitHub-Event` value.

The reason for this change, so so that the router can perform simply is an `X-GitHub-Event` router. Consumers can then use the `IsAuthorized` func to verify the request, or wrap their handler with a `SecretHandler` via the `Authorize` helper. This can be useful for applications which may, for example, have a secret per user.