### PR TITLE
Add package hooker for testing webhooks.

### DIFF
--- a/hooker/hooker.go
+++ b/hooker/hooker.go
@@ -1,0 +1,78 @@
+// package hooker can generate github webhooks. It's only real use is for
+// testing endpoints that handle github webhooks.
+package hooker
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/ejholmes/hookshot"
+)
+
+type Client struct {
+	// Secret is a secret to sign request bodies with.
+	Secret string
+
+	// URL is the url to make requests against.
+	URL string
+
+	client *http.Client
+}
+
+func NewClient(c *http.Client) *Client {
+	if c == nil {
+		c = http.DefaultClient
+	}
+
+	return &Client{
+		client: c,
+	}
+}
+
+func (c *Client) Trigger(event string, v interface{}) (*http.Response, error) {
+	b := new(bytes.Buffer)
+
+	switch v := v.(type) {
+	case io.Reader:
+		if _, err := io.Copy(b, v); err != nil {
+			return nil, err
+		}
+	default:
+		if err := json.NewEncoder(b).Encode(v); err != nil {
+			return nil, err
+		}
+	}
+
+	req, err := http.NewRequest("POST", c.URL, b)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("X-GitHub-Event", event)
+	req.Header.Set("X-Hub-Signature", fmt.Sprintf("sha1=%s", hookshot.Signature(b.Bytes(), c.Secret)))
+
+	return c.Do(req)
+}
+
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if resp.StatusCode/100 != 2 {
+		raw, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return resp, err
+		}
+		resp.Body.Close()
+
+		return resp, fmt.Errorf("hooker: request failed with status %d: %s", resp.StatusCode, raw)
+	}
+
+	return resp, err
+}

--- a/hooker/hooker_test.go
+++ b/hooker/hooker_test.go
@@ -1,0 +1,51 @@
+package hooker
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ejholmes/hookshot"
+)
+
+func TestHooker(t *testing.T) {
+	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := string(raw), `{"Data":"foo"}`+"\n"; got != want {
+			t.Fatalf("Body => %s; want %s", got, want)
+		}
+
+		io.WriteString(w, "ok\n")
+	})
+	s := httptest.NewServer(hookshot.Authorize(h, "secret"))
+	defer s.Close()
+
+	c := NewClient(nil)
+	c.Secret = "secret"
+	c.URL = s.URL
+
+	body := struct {
+		Data string
+	}{
+		Data: "foo",
+	}
+	resp, err := c.Trigger("ping", &body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := string(raw), "ok\n"; got != want {
+		t.Fatalf("Response => %s; want %s", got, want)
+	}
+}


### PR DESCRIPTION
This is being extracted out of https://github.com/remind101/tugboat/tree/master/pkg/hooker. Package `hooker` provides a small http client for sending payloads as github for testing.